### PR TITLE
Update README.md for improved clarity and project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Cerberus
 
-[![Node.js CI](https://github.com/yourusername/cerberus/actions/workflows/test.yml/badge.svg)](https://github.com/yourusername/cerberus/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/yourusername/cerberus/branch/main/graph/badge.svg)](https://codecov.io/gh/yourusername/cerberus)
-[![npm version](https://badge.fury.io/js/cerberus-cli.svg)](https://badge.fury.io/js/cerberus-cli)
+[![Node.js CI](https://github.com/freema/cerberus/actions/workflows/test.yml/badge.svg)](https://github.com/freema/cerberus/actions/workflows/test.yml)
+[![npm version](https://img.shields.io/npm/v/cerberus.svg)](https://www.npmjs.com/package/cerberus)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node version](https://img.shields.io/node/v/cerberus.svg)](https://nodejs.org)
 
 Cerberus is a command-line tool designed to prepare files and projects for Claude AI. It helps developers collect, organize, and analyze source code files to create comprehensive project contexts that can be used as system messages in Claude projects.
 
@@ -52,7 +52,7 @@ Cerberus simplifies the process of working with Claude AI by:
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/cerberus.git
+git clone https://github.com/freema/cerberus.git
 cd cerberus
 
 # Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@graslt/cerberus-claude-cli",
+  "name": "cerberus",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@graslt/cerberus-claude-cli",
+      "name": "cerberus",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@graslt/cerberus-claude-cli",
+  "name": "cerberus",
   "version": "1.0.0",
   "description": "CLI tool for preparing files and projects for Claude AI. Collect, organize, and analyze source code files to create comprehensive project contexts.",
   "main": "bin/cerberus.js",
@@ -33,7 +33,7 @@
     "code-organization",
     "file-bundling"
   ],
-  "author": "graslt",
+  "author": "freema",
   "license": "MIT",
   "homepage": "https://github.com/freema/cerberus#readme",
   "repository": {


### PR DESCRIPTION
This pull request updates the project metadata and documentation to reflect the new ownership and branding of the `Cerberus` project. The changes include updating repository links, author information, package name, and badges in the `README.md` file.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R6): Updated badges to reflect the new repository and branding, including replacing the `codecov` badge with a `Node version` badge.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55): Updated the repository cloning URL to point to the new GitHub repository (`freema/cerberus`).

### Metadata updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R2): Changed the package name from `@graslt/cerberus-claude-cli` to `cerberus` to align with the new branding.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R36): Updated the author field from `graslt` to `freema` to reflect the new ownership.