### PR TITLE
Remove debug step for file structure and linting from CI workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,16 +35,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Debug file structure
-        run: |
-          pwd
-          ls -la src/utils/
-          ls -la src/controllers/
-
       - name: Run checks
         run: |
           npm run test
-          npm run lint
 
       - name: Publish
         run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerberus-claude-cli",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "CLI tool for preparing files and projects for Claude AI. Collect, organize, and analyze source code files to create comprehensive project contexts.",
   "main": "bin/cerberus.js",
   "bin": {


### PR DESCRIPTION
This pull request makes minor updates to the project version and streamlines the CI workflow by removing unnecessary debug steps.

*Version update:*

* Bumped the package version in `package.json` from `1.0.2` to `1.0.3` to reflect the new release.

*CI workflow simplification:*

* Removed the "Debug file structure" step and the `npm run lint` command from the `.github/workflows/publish.yml` workflow to make the publish process cleaner and faster.